### PR TITLE
Standardize, consolidate user ping messages for game updates using Markdown

### DIFF
--- a/fcfb/constants.py
+++ b/fcfb/constants.py
@@ -1,0 +1,26 @@
+PINGING_OFFENSE = """{team} has submitted their number. Please reply to [this comment]({comment_link}) with your number."""
+PINGING_DEFENSE = """The [previous play result]({comment_link}) is in, the difference was **{difference}**. Please respond to [refbot's message]({inbox_link}) with your number."""
+PINGING_GAME_START = """The game has started. Please respond to [refbot's message]({inbox_link}) with *heads* or *tails*."""
+PINGING_COIN_TOSS_WINNER = """The coin flip result is in, you won the toss. Please respond to [refbot's message]({inbox_link}) with your number."""
+REDDIT_PREFIX = "https://old.reddit.com"
+REDDIT_INBOX_LINK = f"{REDDIT_PREFIX}/message/unread/"
+
+def build_reddit_comment_link(comment_permalink: str) -> str:
+    return f"{REDDIT_PREFIX}{comment_permalink}"
+
+def build_ping_offense_message(team: str, comment_permalink: str) -> str:
+    comment_link = build_reddit_comment_link(comment_permalink=comment_permalink)
+    return PINGING_OFFENSE.format(team=team, comment_link=comment_link)
+
+def build_ping_defense_message(difference: str, comment_permalink: str) -> str:
+    comment_link = build_reddit_comment_link(comment_permalink=comment_permalink)
+    return PINGING_DEFENSE.format(difference=difference, comment_link=comment_link, inbox_link=REDDIT_INBOX_LINK)
+
+def build_ping_game_start_message() -> str:
+    return PINGING_GAME_START.format(inbox_link=REDDIT_INBOX_LINK)
+
+def build_ping_coin_toss_winner_message() -> str:
+    return PINGING_COIN_TOSS_WINNER.format(inbox_link=REDDIT_INBOX_LINK)
+
+
+

--- a/fcfb/reddit/reddit_functions.py
+++ b/fcfb/reddit/reddit_functions.py
@@ -1,6 +1,7 @@
 import sys
 
 from fcfb.api.deoxys.processed_comments import get_processed_comment, add_processed_comment
+import fcfb.constants as constants
 from fcfb.discord.utils import ping_user
 
 sys.path.append("..")
@@ -157,9 +158,7 @@ async def find_plays_and_ping(client, r, config_data):
                 user_list = parse_user_from_play_comment(comment)
             else:
                 user_list = parse_multiple_users_from_play_comment(comment)
-            message = (team + " has submitted their number. Please reply to this comment with your number, "
-                       + "feel free to ignore this ping if you already have done so: "
-                       + "<https://old.reddit.com" + comment.permalink + ">")
+            message = constants.build_ping_offense_message(team=team, comment_permalink=comment.permalink)
             for user in user_list:
                 if await ping_user(client, config_data, user, message):
                     await add_processed_comment(config_data, comment.id, submission_id)
@@ -170,26 +169,19 @@ async def find_plays_and_ping(client, r, config_data):
             else:
                 user_list = parse_multiple_users_from_result_comment(comment)
             difference = parse_difference_from_result_comment(comment)
-            message = ("The previous play result is in, the difference was " + difference +
-                       ". Please respond to refbot's message with your number. You can view the result at the link "
-                       + "below, feel free to ignore this ping if you already have done so: "
-                       + "<https://old.reddit.com" + comment.permalink + ">")
+            message = constants.build_ping_defense_message(difference=difference, comment_permalink=comment.permalink)
             for user in user_list:
                 if await ping_user(client, config_data, user, message):
                     await add_processed_comment(config_data, comment.id, submission_id)
         # Handle start of game message, the coin flip
         elif "Happy Gameday!" in comment.body:
             user = parse_user_from_start_comment(comment)
-            message = ("The game has started, please respond to refbot's message with heads or tails. You can view the "
-                       + "result at the link below, feel free to ignore this ping if you already have done so: "
-                       + "<https://old.reddit.com" + comment.permalink + ">")
+            message = constants.build_ping_game_start_message()
             if await ping_user(client, config_data, user, message):
                 await add_processed_comment(config_data, comment.id, submission_id)
         # Handle coin flip result
         elif "won the toss" in comment.body:
             user = parse_user_from_coin_flip_result_comment(comment)
-            message = ("The coin flip result is in, you won the toss. Please respond to refbot's message with your "
-                        + "number. You can view the result at the link below, feel free to ignore this ping if you "
-                        + "already have done so: https://old.reddit.com" + comment.permalink)
+            message = constants.build_ping_coin_toss_winner_message()
             if await ping_user(client, config_data, user, message):
                 await add_processed_comment(config_data, comment.id, submission_id)


### PR DESCRIPTION
To save space and make Discord ping messages easier to parse, especially when there are several of them for all the various concurrent games.

Example:

Old:
<img width="1106" alt="image" src="https://github.com/user-attachments/assets/d7cd6a61-bf08-4086-8f89-7eb83a8d0d2e">

New:
<img width="917" alt="image" src="https://github.com/user-attachments/assets/8edc1537-e766-4c48-92b9-9f70dc22614a">

In this case, the first link goes to refbot's play-result comment, while the second link opens the current Reddit user's own inbox (for more direct navigation to the refbot message). The difference number is also bolded to make it stand out more. On a standard desktop screen, three lines of text have been reduced to one line; on a modern smartphone, six lines of text have been reduced to two.